### PR TITLE
Update releases.properties from release 2026.3.4

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -4,6 +4,7 @@
 9.2.0 = https://github.com/Bearsampp/module-mysql/releases/download/2025.1.23/bearsampp-mysql-9.2.0-2025.1.23.7z
 9.1.0 = https://github.com/Bearsampp/module-mysql/releases/download/2024.12.1/bearsampp-mysql-9.1.0-2024.12.1.7z
 9.0.1 = https://github.com/Bearsampp/module-mysql/releases/download/2024.7.28/bearsampp-mysql-9.0.1-2024.8.7.7z
+8.4.8 = https://github.com/Bearsampp/module-mysql/releases/download/2026.3.4/bearsampp-mysql-8.4.8-2026.3.4.7z
 8.4.7 = https://github.com/Bearsampp/module-mysql/releases/download/2025.11.23/bearsampp-mysql-8.4.7-2025.11.23.7z
 8.4.6 = https://github.com/Bearsampp/module-mysql/releases/download/2025.8.21/bearsampp-mysql-8.4.6-2025.8.21.7z
 8.4.5 = https://github.com/Bearsampp/module-mysql/releases/download/2025.4.18/bearsampp-mysql-8.4.5-2025.4.18.7z
@@ -12,6 +13,7 @@
 8.4.2 = https://github.com/Bearsampp/module-mysql/releases/download/2024.7.28/bearsampp-mysql-8.4.2-2024.7.28.7z
 8.4 = https://github.com/Bearsampp/module-mysql/releases/download/2024.6.14/bearsampp-mysql-8.4-2024.6.14.7z
 8.3.0 = https://github.com/Bearsampp/module-mysql/releases/download/2024.6.14/bearsampp-mysql-8.3.0-2024.6.14.7z
+8.0.45 = https://github.com/Bearsampp/module-mysql/releases/download/2026.3.4/bearsampp-mysql-8.0.45-2026.3.4.7z
 8.0.44 = https://github.com/Bearsampp/module-mysql/releases/download/2025.11.23/bearsampp-mysql-8.0.44-2025.11.23.7z
 8.0.42 = https://github.com/Bearsampp/module-mysql/releases/download/2025.4.18/bearsampp-mysql-8.0.42-2025.4.18.7z
 8.0.41 = https://github.com/Bearsampp/module-mysql/releases/download/2025.1.23/bearsampp-mysql-8.0.41-2025.1.23.7z


### PR DESCRIPTION
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2026.3.4`.

### Changes:
- Extracted .7z assets from the release
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-mysql/releases/tag/2026.3.4

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs